### PR TITLE
Report exception/important matches through `engine.matches` API

### DIFF
--- a/src/lib.h
+++ b/src/lib.h
@@ -30,34 +30,37 @@ bool set_domain_resolver(C_DomainResolverCallback resolver);
 /**
  * Create a new `Engine`.
  */
-C_Engine *engine_create(const char *rules);
+struct C_Engine *engine_create(const char *rules);
 
 /**
  * Checks if a `url` matches for the specified `Engine` within the context.
  */
-bool engine_match(C_Engine *engine,
+bool engine_match(struct C_Engine *engine,
                   const char *url,
                   const char *host,
                   const char *tab_host,
                   bool third_party,
                   const char *resource_type,
-                  bool *saved_from_exception,
-                  char **redirect);
+                  bool *did_match_exception,
+                  bool *did_match_important,
+                  char **redirect,
+                  bool previously_matched_rule,
+                  bool force_check_exceptions);
 
 /**
  * Adds a tag to the engine for consideration
  */
-void engine_add_tag(C_Engine *engine, const char *tag);
+void engine_add_tag(struct C_Engine *engine, const char *tag);
 
 /**
  * Checks if a tag exists in the engine
  */
-bool engine_tag_exists(C_Engine *engine, const char *tag);
+bool engine_tag_exists(struct C_Engine *engine, const char *tag);
 
 /**
  * Adds a resource to the engine by name
  */
-bool engine_add_resource(C_Engine *engine,
+bool engine_add_resource(struct C_Engine *engine,
                          const char *key,
                          const char *content_type,
                          const char *data);
@@ -65,22 +68,22 @@ bool engine_add_resource(C_Engine *engine,
 /**
  * Adds a list of `Resource`s from JSON format
  */
-void engine_add_resources(C_Engine *engine, const char *resources);
+void engine_add_resources(struct C_Engine *engine, const char *resources);
 
 /**
  * Removes a tag to the engine for consideration
  */
-void engine_remove_tag(C_Engine *engine, const char *tag);
+void engine_remove_tag(struct C_Engine *engine, const char *tag);
 
 /**
  * Deserializes a previously serialized data file list.
  */
-bool engine_deserialize(C_Engine *engine, const char *data, size_t data_size);
+bool engine_deserialize(struct C_Engine *engine, const char *data, size_t data_size);
 
 /**
  * Destroy a `Engine` once you are done with it.
  */
-void engine_destroy(C_Engine *engine);
+void engine_destroy(struct C_Engine *engine);
 
 /**
  * Destroy a `*c_char` once you are done with it.
@@ -90,14 +93,14 @@ void c_char_buffer_destroy(char *s);
 /**
  * Returns a set of cosmetic filtering resources specific to the given url, in JSON format
  */
-char *engine_url_cosmetic_resources(C_Engine *engine, const char *url);
+char *engine_url_cosmetic_resources(struct C_Engine *engine, const char *url);
 
 /**
  * Returns a stylesheet containing all generic cosmetic rules that begin with any of the provided class and id selectors
  *
  * The leading '.' or '#' character should not be provided
  */
-char *engine_hidden_class_id_selectors(C_Engine *engine,
+char *engine_hidden_class_id_selectors(struct C_Engine *engine,
                                        const char *const *classes,
                                        size_t classes_size,
                                        const char *const *ids,

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -45,12 +45,13 @@ Engine::Engine(const std::string& rules) : raw(engine_create(rules.c_str())) {
 
 bool Engine::matches(const std::string& url, const std::string& host,
     const std::string& tab_host, bool is_third_party,
-    const std::string& resource_type, bool* saved_from_exception,
-    std::string* redirect) {
+    const std::string& resource_type, bool* did_match_exception,
+    bool* did_match_important, std::string* redirect, bool
+    previously_matched_rule, bool previously_matched_exception) {
   char* redirect_char_ptr = nullptr;
   bool result = engine_match(raw, url.c_str(), host.c_str(),tab_host.c_str(),
-      is_third_party, resource_type.c_str(), saved_from_exception,
-      &redirect_char_ptr);
+      is_third_party, resource_type.c_str(), did_match_exception, did_match_important,
+      &redirect_char_ptr, previously_matched_rule, previously_matched_exception);
   if (redirect_char_ptr) {
     if (redirect) {
       *redirect = redirect_char_ptr;

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -65,8 +65,9 @@ class ADBLOCK_EXPORT Engine {
   Engine(const std::string& rules);
   bool matches(const std::string& url, const std::string& host,
       const std::string& tab_host, bool is_third_party,
-      const std::string& resource_type, bool* saved_from_exception,
-      std::string *redirect);
+      const std::string& resource_type, bool* did_match_exception,
+      bool* did_match_important, std::string *redirect,
+      bool previously_matched_rule, bool previously_matched_exception);
   bool deserialize(const char* data, size_t data_size);
   void addTag(const std::string& tag);
   void addResource(const std::string& key,


### PR DESCRIPTION
This introduces a new boolean output argument to `engine.matches` that represents whether or not a matched network filter is `important`.

Additionally, this changes `saved_from_exception` to just `did_match_exception` and uses `true` as the return value only when a filter matches. This way, it's possible to determine whether or not an exception matched even if no filter was matched.

Depends on changes from brave/adblock-rust/pull/42

Intended as part of the fix for brave/brave-browser#5440