### PR TITLE
Use Cow for resource MimeTypes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ pub unsafe extern "C" fn engine_add_resource(
     let resource = Resource {
         name: key.to_string(),
         aliases: vec![],
-        kind: ResourceType::Mime(MimeType::from(content_type)),
+        kind: ResourceType::Mime(MimeType::from(std::borrow::Cow::from(content_type))),
         content: data.to_string(),
     };
     assert!(!engine.is_null());


### PR DESCRIPTION
This change will be required once the dependency on `adblock-rust` is updated past https://github.com/brave/adblock-rust/commit/1d70bb092da14de505ed7bfe900ae8ecd2bb99a4.