### PR TITLE
Match newer selectors API of adblock-rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@
 [[package]]
 name = "adblock"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/brave/adblock-rust?rev=fab2ae2b21bb4be052faa1d70dde34c61628a910#fab2ae2b21bb4be052faa1d70dde34c61628a910"
 dependencies = [
  "addr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -30,7 +30,7 @@ dependencies = [
 name = "adblock-ffi"
 version = "0.1.0"
 dependencies = [
- "adblock 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "adblock 0.2.1 (git+https://github.com/brave/adblock-rust?rev=fab2ae2b21bb4be052faa1d70dde34c61628a910)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -817,7 +817,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum adblock 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2b70774de0a290f4504b2f4aaf21e88359590d9c3381a16c66bbb0fbe47b6889"
+"checksum adblock 0.2.1 (git+https://github.com/brave/adblock-rust?rev=fab2ae2b21bb4be052faa1d70dde34c61628a910)" = "<none>"
 "checksum addr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22199dd03e5cff19ede8c2b835c93460f998b4716e225d06d740d925ceac5d75"
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum ahash 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6f33b5018f120946c1dcf279194f238a9f146725593ead1c08fa47ff22b0b5d3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Brian R. Bondy <netzen@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-adblock="~0.2.1"
+adblock = { version = "~0.2.1", git = "https://github.com/brave/adblock-rust", rev = "fab2ae2b21bb4be052faa1d70dde34c61628a910" }
 serde_json = "1.0"
 libc = "0.2"
 

--- a/examples/cpp/main.cpp
+++ b/examples/cpp/main.cpp
@@ -244,27 +244,27 @@ void TestClassId() {
   std::vector<std::string> classes = std::vector<std::string>();
   std::vector<std::string> ids = std::vector<std::string>();
   std::vector<std::string> exceptions = std::vector<std::string>();
-  std::string stylesheet = engine.classIdStylesheet(classes, ids, exceptions);
-  assert(stylesheet == "");
+  std::string stylesheet = engine.hiddenClassIdSelectors(classes, ids, exceptions);
+  assert(stylesheet == "[]");
 
   classes = std::vector<std::string>({"ads", "no-ads"});
   ids = std::vector<std::string>({"element"});
   exceptions = std::vector<std::string>();
-  stylesheet = engine.classIdStylesheet(classes, ids, exceptions);
-  assert(stylesheet == ".ads,#element{display:none !important;}");
+  stylesheet = engine.hiddenClassIdSelectors(classes, ids, exceptions);
+  assert(stylesheet == "[\".ads\",\"#element\"]");
 
   classes = std::vector<std::string>({"element", "a"});
   ids = std::vector<std::string>({"block", "ads", "a"});
   exceptions = std::vector<std::string>({"#block"});
-  stylesheet = engine.classIdStylesheet(classes, ids, exceptions);
-  assert(stylesheet == ".element,#block + .child,#ads > #element{display:none !important;}");
+  stylesheet = engine.hiddenClassIdSelectors(classes, ids, exceptions);
+  assert(stylesheet == "[\".element\",\"#block + .child\",\"#ads > #element\"]");
 
   // Classes and ids must be passed without the leading `.` or `#`, or they will not be recognized
   classes = std::vector<std::string>({".element", ".a"});
   ids = std::vector<std::string>({"#block", "#ads", "#a"});
   exceptions = std::vector<std::string>({"block"});
-  stylesheet = engine.classIdStylesheet(classes, ids, exceptions);
-  assert(stylesheet == "");
+  stylesheet = engine.hiddenClassIdSelectors(classes, ids, exceptions);
+  assert(stylesheet == "[]");
 }
 
 void TestHostnameCosmetics() {

--- a/src/lib.h
+++ b/src/lib.h
@@ -46,18 +46,6 @@ void engine_add_resources(C_Engine *engine, const char *resources);
 void engine_add_tag(C_Engine *engine, const char *tag);
 
 /**
- * Returns a stylesheet containing all generic cosmetic rules that begin with any of the provided class and id selectors
- * The leading '.' or '#' character should not be provided
- */
-char *engine_class_id_stylesheet(C_Engine *engine,
-                                 const char *const *classes,
-                                 size_t classes_size,
-                                 const char *const *ids,
-                                 size_t ids_size,
-                                 const char *const *exceptions,
-                                 size_t exceptions_size);
-
-/**
  * Create a new `Engine`.
  */
 C_Engine *engine_create(const char *rules);
@@ -71,6 +59,18 @@ bool engine_deserialize(C_Engine *engine, const char *data, size_t data_size);
  * Destroy a `Engine` once you are done with it.
  */
 void engine_destroy(C_Engine *engine);
+
+/**
+ * Returns a stylesheet containing all generic cosmetic rules that begin with any of the provided class and id selectors
+ * The leading '.' or '#' character should not be provided
+ */
+char *engine_hidden_class_id_selectors(C_Engine *engine,
+                                       const char *const *classes,
+                                       size_t classes_size,
+                                       const char *const *ids,
+                                       size_t ids_size,
+                                       const char *const *exceptions,
+                                       size_t exceptions_size);
 
 /**
  * Returns a set of cosmetic filtering resources specific to the given hostname, in JSON format

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@ pub unsafe extern "C" fn engine_hostname_cosmetic_resources(
 ///
 /// The leading '.' or '#' character should not be provided
 #[no_mangle]
-pub unsafe extern "C" fn engine_class_id_stylesheet(
+pub unsafe extern "C" fn engine_hidden_class_id_selectors(
     engine: *mut Engine,
     classes: *const *const c_char,
     classes_size: size_t,
@@ -272,6 +272,6 @@ pub unsafe extern "C" fn engine_class_id_stylesheet(
         .collect();
     assert!(!engine.is_null());
     let engine = Box::leak(Box::from_raw(engine));
-    let stylesheet = engine.class_id_stylesheet(&classes, &ids, &exceptions);
-    CString::new(stylesheet.unwrap_or_else(|| String::new())).expect("Error: CString::new()").into_raw()
+    let stylesheet = engine.hidden_class_id_selectors(&classes, &ids, &exceptions);
+    CString::new(serde_json::to_string(&stylesheet).unwrap_or_else(|_| "".into())).expect("Error: CString::new()").into_raw()
 }

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -130,7 +130,7 @@ const std::string Engine::hostnameCosmeticResources(const std::string& hostname)
   return resources_json;
 }
 
-const std::string Engine::classIdStylesheet(const std::vector<std::string>& classes, const std::vector<std::string>& ids, const std::vector<std::string>& exceptions) {
+const std::string Engine::hiddenClassIdSelectors(const std::vector<std::string>& classes, const std::vector<std::string>& ids, const std::vector<std::string>& exceptions) {
   std::vector<const char*> classes_raw;
   classes_raw.reserve(classes.size());
   for(size_t i = 0; i < classes.size(); i++) {
@@ -149,7 +149,7 @@ const std::string Engine::classIdStylesheet(const std::vector<std::string>& clas
     exceptions_raw.push_back(exceptions[i].c_str());
   }
 
-  char* stylesheet_raw = engine_class_id_stylesheet(
+  char* stylesheet_raw = engine_hidden_class_id_selectors(
     raw,
     classes_raw.data(), classes.size(),
     ids_raw.data(), ids.size(),

--- a/src/wrapper.hpp
+++ b/src/wrapper.hpp
@@ -58,7 +58,7 @@ class Engine {
   void removeTag(const std::string& tag);
   bool tagExists(const std::string& tag);
   const std::string hostnameCosmeticResources(const std::string& hostname);
-  const std::string classIdStylesheet(
+  const std::string hiddenClassIdSelectors(
       const std::vector<std::string>& classes,
       const std::vector<std::string>& ids,
       const std::vector<std::string>& exceptions


### PR DESCRIPTION
Reflects changes from https://github.com/brave/adblock-rust/pull/63, required for https://github.com/brave/brave-core/pull/4269.

I changed the dependency on `adblock-rust` to be a commit hash from GitHub as I don't have permission to push the changes above to crates.io.