### PR TITLE
Free memory correctly

### DIFF
--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -126,7 +126,7 @@ const std::string Engine::hostnameCosmeticResources(const std::string& hostname)
   char* resources_raw = engine_hostname_cosmetic_resources(raw, hostname.c_str());
   const std::string resources_json = std::string(resources_raw);
 
-  free(resources_raw);
+  c_char_buffer_destroy(resources_raw);
   return resources_json;
 }
 
@@ -157,7 +157,7 @@ const std::string Engine::hiddenClassIdSelectors(const std::vector<std::string>&
   );
   const std::string stylesheet = std::string(stylesheet_raw);
 
-  free(stylesheet_raw);
+  c_char_buffer_destroy(stylesheet_raw);
   return stylesheet;
 }
 


### PR DESCRIPTION
As per https://doc.rust-lang.org/std/ffi/struct.CString.html#method.into_raw, `free` should not be called on strings passed across the FFI. They should be passed back and reconstructed into `CString`s so that Rust can deallocate them properly.

My fault for not noticing that you'd already added `c_char_buffer_destroy` for this purpose!