### PR TITLE
Expose support for generichide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,8 +2,8 @@
 # It is not intended for manual editing.
 [[package]]
 name = "adblock"
-version = "0.2.6"
-source = "git+https://github.com/brave/adblock-rust?rev=abd51752fab1f7aafb09d0fc410809b2b65abbf6#abd51752fab1f7aafb09d0fc410809b2b65abbf6"
+version = "0.2.10"
+source = "git+https://github.com/brave/adblock-rust?rev=27409e39687adfa68f883153c878a0d8f2d655e9#27409e39687adfa68f883153c878a0d8f2d655e9"
 dependencies = [
  "addr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -30,7 +30,7 @@ dependencies = [
 name = "adblock-ffi"
 version = "0.1.0"
 dependencies = [
- "adblock 0.2.6 (git+https://github.com/brave/adblock-rust?rev=abd51752fab1f7aafb09d0fc410809b2b65abbf6)",
+ "adblock 0.2.10 (git+https://github.com/brave/adblock-rust?rev=27409e39687adfa68f883153c878a0d8f2d655e9)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -817,7 +817,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum adblock 0.2.6 (git+https://github.com/brave/adblock-rust?rev=abd51752fab1f7aafb09d0fc410809b2b65abbf6)" = "<none>"
+"checksum adblock 0.2.10 (git+https://github.com/brave/adblock-rust?rev=27409e39687adfa68f883153c878a0d8f2d655e9)" = "<none>"
 "checksum addr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22199dd03e5cff19ede8c2b835c93460f998b4716e225d06d740d925ceac5d75"
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum ahash 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6f33b5018f120946c1dcf279194f238a9f146725593ead1c08fa47ff22b0b5d3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Brian R. Bondy <netzen@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-adblock = { version = "~0.2.6", git = "https://github.com/brave/adblock-rust", rev = "abd51752fab1f7aafb09d0fc410809b2b65abbf6" }
+adblock = { version = "~0.2.10", git = "https://github.com/brave/adblock-rust", rev = "27409e39687adfa68f883153c878a0d8f2d655e9" }
 serde_json = "1.0"
 libc = "0.2"
 

--- a/src/lib.h
+++ b/src/lib.h
@@ -75,11 +75,6 @@ char *engine_hidden_class_id_selectors(C_Engine *engine,
                                        size_t exceptions_size);
 
 /**
- * Returns a set of cosmetic filtering resources specific to the given hostname, in JSON format
- */
-char *engine_hostname_cosmetic_resources(C_Engine *engine, const char *hostname);
-
-/**
  * Checks if a `url` matches for the specified `Engine` within the context.
  */
 bool engine_match(C_Engine *engine,
@@ -101,6 +96,11 @@ void engine_remove_tag(C_Engine *engine, const char *tag);
  * Checks if a tag exists in the engine
  */
 bool engine_tag_exists(C_Engine *engine, const char *tag);
+
+/**
+ * Returns a set of cosmetic filtering resources specific to the given url, in JSON format
+ */
+char *engine_url_cosmetic_resources(C_Engine *engine, const char *url);
 
 /**
  * Get the specific default list size

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,16 +232,16 @@ pub unsafe extern "C" fn filter_list_get(category: *const c_char, i: size_t) -> 
     new_list
 }
 
-/// Returns a set of cosmetic filtering resources specific to the given hostname, in JSON format
+/// Returns a set of cosmetic filtering resources specific to the given url, in JSON format
 #[no_mangle]
-pub unsafe extern "C" fn engine_hostname_cosmetic_resources(
+pub unsafe extern "C" fn engine_url_cosmetic_resources(
     engine: *mut Engine,
-    hostname: *const c_char,
+    url: *const c_char,
 ) -> *mut c_char {
-    let hostname = CStr::from_ptr(hostname).to_str().unwrap();
+    let url = CStr::from_ptr(url).to_str().unwrap();
     assert!(!engine.is_null());
     let engine = Box::leak(Box::from_raw(engine));
-    let ptr = CString::new(serde_json::to_string(&engine.hostname_cosmetic_resources(hostname))
+    let ptr = CString::new(serde_json::to_string(&engine.url_cosmetic_resources(url))
         .unwrap_or_else(|_| "".into()))
         .expect("Error: CString::new()")
         .into_raw();

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -125,8 +125,8 @@ void Engine::addResources(const std::string& resources) {
   engine_add_resources(raw, resources.c_str());
 }
 
-const std::string Engine::hostnameCosmeticResources(const std::string& hostname) {
-  char* resources_raw = engine_hostname_cosmetic_resources(raw, hostname.c_str());
+const std::string Engine::urlCosmeticResources(const std::string& url) {
+  char* resources_raw = engine_url_cosmetic_resources(raw, url.c_str());
   const std::string resources_json = std::string(resources_raw);
 
   c_char_buffer_destroy(resources_raw);

--- a/src/wrapper.hpp
+++ b/src/wrapper.hpp
@@ -59,7 +59,7 @@ class Engine {
   void addResources(const std::string& resources);
   void removeTag(const std::string& tag);
   bool tagExists(const std::string& tag);
-  const std::string hostnameCosmeticResources(const std::string& hostname);
+  const std::string urlCosmeticResources(const std::string& url);
   const std::string hiddenClassIdSelectors(
       const std::vector<std::string>& classes,
       const std::vector<std::string>& ids,


### PR DESCRIPTION
Will allow changes from https://github.com/brave/adblock-rust/pull/97 so that `generichide` exception logic can be used from the browser.