### PR TITLE
update adblock-rust to v0.3 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,8 +2,8 @@
 # It is not intended for manual editing.
 [[package]]
 name = "adblock"
-version = "0.2.10"
-source = "git+https://github.com/brave/adblock-rust?rev=27409e39687adfa68f883153c878a0d8f2d655e9#27409e39687adfa68f883153c878a0d8f2d655e9"
+version = "0.3.0"
+source = "git+https://github.com/brave/adblock-rust?rev=96627d0a12a65effb2a45e9f16ae8d89416bfacd#96627d0a12a65effb2a45e9f16ae8d89416bfacd"
 dependencies = [
  "addr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -30,7 +30,7 @@ dependencies = [
 name = "adblock-ffi"
 version = "0.1.0"
 dependencies = [
- "adblock 0.2.10 (git+https://github.com/brave/adblock-rust?rev=27409e39687adfa68f883153c878a0d8f2d655e9)",
+ "adblock 0.3.0 (git+https://github.com/brave/adblock-rust?rev=96627d0a12a65effb2a45e9f16ae8d89416bfacd)",
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -808,7 +808,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum adblock 0.2.10 (git+https://github.com/brave/adblock-rust?rev=27409e39687adfa68f883153c878a0d8f2d655e9)" = "<none>"
+"checksum adblock 0.3.0 (git+https://github.com/brave/adblock-rust?rev=96627d0a12a65effb2a45e9f16ae8d89416bfacd)" = "<none>"
 "checksum addr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22199dd03e5cff19ede8c2b835c93460f998b4716e225d06d740d925ceac5d75"
 "checksum addr2line 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Brian R. Bondy <netzen@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-adblock = { version = "~0.2.10", git = "https://github.com/brave/adblock-rust", rev = "7fdd43d7ea79d078dd3807fffcefbb3d0b583bcc" }
+adblock = { version = "~0.3.0", git = "https://github.com/brave/adblock-rust", rev = "96627d0a12a65effb2a45e9f16ae8d89416bfacd" }
 serde_json = "1.0"
 libc = "0.2"
 

--- a/examples/cpp/main.cpp
+++ b/examples/cpp/main.cpp
@@ -120,21 +120,6 @@ void TestBasics() {
       "example.com", "example.com", false, "image");
 }
 
-void TestAddingFilters() {
-  Engine engine("");
-  engine.addFilter("-advertisement-icon.");
-  engine.addFilter("-advertisement-management");
-  engine.addFilter("-advertisement.");
-  engine.addFilter("-advertisement/script.");
-  engine.addFilter("@@good-advertisement");
-  Check(true, false, false, "", "Basic match", engine, "http://example.com/-advertisement-icon.",
-      "example.com", "example.com", false , "image");
-  Check(false, false, false, "", "Basic not match", engine, "https://brianbondy.com",
-      "brianbondy.com", "example.com", true, "image");
-  Check(false, false, true, "", "Basic saved from exception", engine, "http://example.com/good-advertisement-icon.",
-      "example.com", "example.com", false, "image");
-}
-
 void TestDeserialization() {
   Engine engine("");
   engine.deserialize(reinterpret_cast<const char*>(ad_banner_dat_buffer),
@@ -374,7 +359,7 @@ void TestGenerichide() {
 
 void TestDefaultLists() {
   std::vector<FilterList>& default_lists = FilterList::GetDefaultLists();
-  assert(default_lists.size() == 9);
+  assert(default_lists.size() == 10);
   FilterList& l = default_lists[0];
   assert(l.uuid == "67F880F5-7602-4042-8A3D-01481FD7437A");
   assert(l.url == "https://easylist.to/easylist/easylist.txt");
@@ -387,7 +372,7 @@ void TestDefaultLists() {
   num_passed++;
 
   // Includes Brave Disconnect list
-  FilterList& l2 = default_lists[7];
+  FilterList& l2 = default_lists[8];
   assert(l2.uuid == "9FA0665A-8FC0-4590-A80A-3FF6117A1258");
   assert(l2.url == "https://raw.githubusercontent.com"
       "/brave/adblock-lists/master/brave-disconnect.txt");
@@ -412,7 +397,6 @@ void TestRegionalLists() {
 
 int main() {
   TestBasics();
-  TestAddingFilters();
   TestDeserialization();
   TestTags();
   TestRedirects();

--- a/src/lib.h
+++ b/src/lib.h
@@ -26,8 +26,6 @@ typedef struct {
  */
 void c_char_buffer_destroy(char *s);
 
-void engine_add_filter(C_Engine *engine, const char *filter);
-
 /**
  * Adds a resource to the engine by name
  */

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -111,10 +111,6 @@ bool Engine::tagExists(const std::string& tag) {
   return engine_tag_exists(raw, tag.c_str());
 }
 
-void Engine::addFilter(const std::string& filter) {
-  engine_add_filter(raw, filter.c_str());
-}
-
 void Engine::addResource(const std::string& key,
     const std::string& content_type,
     const std::string &data) {

--- a/src/wrapper.hpp
+++ b/src/wrapper.hpp
@@ -51,7 +51,6 @@ class Engine {
       bool* saved_from_exception,
       std::string *redirect);
   bool deserialize(const char* data, size_t data_size);
-  void addFilter(const std::string& filter);
   void addTag(const std::string& tag);
   void addResource(const std::string& key,
       const std::string& content_type,


### PR DESCRIPTION
Only difference to the public API here is the removal of `addFilter`, which isn't used in `brave-core` anyways