### PR TITLE
Support adblock-rust 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,8 +2,8 @@
 # It is not intended for manual editing.
 [[package]]
 name = "adblock"
-version = "0.3.3"
-source = "git+https://github.com/brave/adblock-rust?rev=7be07ff8b22fb523feac4b4f5d8c2f00eaf9a01f#7be07ff8b22fb523feac4b4f5d8c2f00eaf9a01f"
+version = "0.3.4"
+source = "git+https://github.com/brave/adblock-rust?rev=c647890b6d065daf98cba540d2232c100698c498#c647890b6d065daf98cba540d2232c100698c498"
 dependencies = [
  "base64",
  "bitflags",
@@ -53,12 +53,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "base64"
-version = "0.10.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
@@ -118,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -139,15 +136,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "lifeguard"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee00513d51f9a08737b74a286c761fc641114d1d5d6329beb11510049ec405f"
+checksum = "89be94dbd775db37b46ca4f4bf5cf89adfb13ba197bfbcb69b2122848ee73c26"
 
 [[package]]
 name = "matches"
@@ -181,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.4.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "percent-encoding"
@@ -211,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.9"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -223,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.18"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "rmp"
@@ -282,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.53"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
+checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Brian R. Bondy <netzen@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-adblock = { version = "~0.3.3", git = "https://github.com/brave/adblock-rust", rev = "7be07ff8b22fb523feac4b4f5d8c2f00eaf9a01f", default-features = false, features = ["full-regex-handling", "object-pooling"] }
+adblock = { version = "~0.3.4", git = "https://github.com/brave/adblock-rust", rev = "c647890b6d065daf98cba540d2232c100698c498", default-features = false, features = ["full-regex-handling", "object-pooling"] }
 serde_json = "1.0"
 libc = "0.2"
 

--- a/src/lib.h
+++ b/src/lib.h
@@ -6,6 +6,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+/**
+ * Main adblocking engine that allows efficient querying of resources to block.
+ */
 typedef struct C_Engine C_Engine;
 
 /**
@@ -16,14 +19,45 @@ typedef struct C_Engine C_Engine;
 typedef void (*C_DomainResolverCallback)(const char*, uint32_t*, uint32_t*);
 
 /**
- * Destroy a `*c_char` once you are done with it.
+ * Passes a callback to the adblock library, allowing it to be used for domain resolution.
+ *
+ * This is required to be able to use any adblocking functionality.
+ *
+ * Returns true on success, false if a callback was already set previously.
  */
-void c_char_buffer_destroy(char *s);
+bool set_domain_resolver(C_DomainResolverCallback resolver);
+
+/**
+ * Create a new `Engine`.
+ */
+C_Engine *engine_create(const char *rules);
+
+/**
+ * Checks if a `url` matches for the specified `Engine` within the context.
+ */
+bool engine_match(C_Engine *engine,
+                  const char *url,
+                  const char *host,
+                  const char *tab_host,
+                  bool third_party,
+                  const char *resource_type,
+                  bool *saved_from_exception,
+                  char **redirect);
+
+/**
+ * Adds a tag to the engine for consideration
+ */
+void engine_add_tag(C_Engine *engine, const char *tag);
+
+/**
+ * Checks if a tag exists in the engine
+ */
+bool engine_tag_exists(C_Engine *engine, const char *tag);
 
 /**
  * Adds a resource to the engine by name
  */
-void engine_add_resource(C_Engine *engine,
+bool engine_add_resource(C_Engine *engine,
                          const char *key,
                          const char *content_type,
                          const char *data);
@@ -34,14 +68,9 @@ void engine_add_resource(C_Engine *engine,
 void engine_add_resources(C_Engine *engine, const char *resources);
 
 /**
- * Adds a tag to the engine for consideration
+ * Removes a tag to the engine for consideration
  */
-void engine_add_tag(C_Engine *engine, const char *tag);
-
-/**
- * Create a new `Engine`.
- */
-C_Engine *engine_create(const char *rules);
+void engine_remove_tag(C_Engine *engine, const char *tag);
 
 /**
  * Deserializes a previously serialized data file list.
@@ -52,6 +81,16 @@ bool engine_deserialize(C_Engine *engine, const char *data, size_t data_size);
  * Destroy a `Engine` once you are done with it.
  */
 void engine_destroy(C_Engine *engine);
+
+/**
+ * Destroy a `*c_char` once you are done with it.
+ */
+void c_char_buffer_destroy(char *s);
+
+/**
+ * Returns a set of cosmetic filtering resources specific to the given url, in JSON format
+ */
+char *engine_url_cosmetic_resources(C_Engine *engine, const char *url);
 
 /**
  * Returns a stylesheet containing all generic cosmetic rules that begin with any of the provided class and id selectors
@@ -65,42 +104,5 @@ char *engine_hidden_class_id_selectors(C_Engine *engine,
                                        size_t ids_size,
                                        const char *const *exceptions,
                                        size_t exceptions_size);
-
-/**
- * Checks if a `url` matches for the specified `Engine` within the context.
- */
-bool engine_match(C_Engine *engine,
-                  const char *url,
-                  const char *host,
-                  const char *tab_host,
-                  bool third_party,
-                  const char *resource_type,
-                  bool *explicit_cancel,
-                  bool *saved_from_exception,
-                  char **redirect);
-
-/**
- * Removes a tag to the engine for consideration
- */
-void engine_remove_tag(C_Engine *engine, const char *tag);
-
-/**
- * Checks if a tag exists in the engine
- */
-bool engine_tag_exists(C_Engine *engine, const char *tag);
-
-/**
- * Returns a set of cosmetic filtering resources specific to the given url, in JSON format
- */
-char *engine_url_cosmetic_resources(C_Engine *engine, const char *url);
-
-/**
- * Passes a callback to the adblock library, allowing it to be used for domain resolution.
- *
- * This is required to be able to use any adblocking functionality.
- *
- * Returns true on success, false if a callback was already set previously.
- */
-bool set_domain_resolver(C_DomainResolverCallback resolver);
 
 #endif /* ADBLOCK_RUST_FFI_H */

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -45,12 +45,12 @@ Engine::Engine(const std::string& rules) : raw(engine_create(rules.c_str())) {
 
 bool Engine::matches(const std::string& url, const std::string& host,
     const std::string& tab_host, bool is_third_party,
-    const std::string& resource_type, bool* explicit_cancel,
-    bool* saved_from_exception, std::string* redirect) {
+    const std::string& resource_type, bool* saved_from_exception,
+    std::string* redirect) {
   char* redirect_char_ptr = nullptr;
   bool result = engine_match(raw, url.c_str(), host.c_str(),tab_host.c_str(),
-      is_third_party, resource_type.c_str(), explicit_cancel,
-      saved_from_exception, &redirect_char_ptr);
+      is_third_party, resource_type.c_str(), saved_from_exception,
+      &redirect_char_ptr);
   if (redirect_char_ptr) {
     if (redirect) {
       *redirect = redirect_char_ptr;

--- a/src/wrapper.hpp
+++ b/src/wrapper.hpp
@@ -65,8 +65,7 @@ class ADBLOCK_EXPORT Engine {
   Engine(const std::string& rules);
   bool matches(const std::string& url, const std::string& host,
       const std::string& tab_host, bool is_third_party,
-      const std::string& resource_type, bool* explicit_cancel,
-      bool* saved_from_exception,
+      const std::string& resource_type, bool* saved_from_exception,
       std::string *redirect);
   bool deserialize(const char* data, size_t data_size);
   void addTag(const std::string& tag);


### PR DESCRIPTION
Removes the now unused `explicitcancel` filter option and required before https://github.com/brave/brave-browser/issues/13101 can be fixed