### PR TITLE
Adhere to chromium style guide for input/output parameter order

### DIFF
--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -45,9 +45,9 @@ Engine::Engine(const std::string& rules) : raw(engine_create(rules.c_str())) {
 
 bool Engine::matches(const std::string& url, const std::string& host,
     const std::string& tab_host, bool is_third_party,
-    const std::string& resource_type, bool* did_match_exception,
-    bool* did_match_important, std::string* redirect, bool
-    previously_matched_rule, bool previously_matched_exception) {
+    const std::string& resource_type, bool previously_matched_rule,
+    bool previously_matched_exception, std::string* redirect,
+    bool* did_match_exception, bool* did_match_important) {
   char* redirect_char_ptr = nullptr;
   bool result = engine_match(raw, url.c_str(), host.c_str(),tab_host.c_str(),
       is_third_party, resource_type.c_str(), did_match_exception, did_match_important,

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -65,9 +65,9 @@ class ADBLOCK_EXPORT Engine {
   Engine(const std::string& rules);
   bool matches(const std::string& url, const std::string& host,
       const std::string& tab_host, bool is_third_party,
-      const std::string& resource_type, bool* did_match_exception,
-      bool* did_match_important, std::string *redirect,
-      bool previously_matched_rule, bool previously_matched_exception);
+      const std::string& resource_type, bool previously_matched_rule,
+      bool previously_matched_exception, std::string *redirect,
+      bool* did_match_exception, bool* did_match_important);
   bool deserialize(const char* data, size_t data_size);
   void addTag(const std::string& tag);
   void addResource(const std::string& key,


### PR DESCRIPTION
As per @iefremov's feedback [here](https://github.com/brave/brave-core/pull/7666#discussion_r563707642)