### PR TITLE
Use inout params to simplify matches API

### DIFF
--- a/src/lib.h
+++ b/src/lib.h
@@ -34,18 +34,21 @@ struct C_Engine *engine_create(const char *rules);
 
 /**
  * Checks if a `url` matches for the specified `Engine` within the context.
+ *
+ * This API is designed for multi-engine use, so block results are used both as inputs and
+ * outputs. They will be updated to reflect additional checking within this engine, rather than
+ * being replaced with results just for this engine.
  */
-bool engine_match(struct C_Engine *engine,
+void engine_match(struct C_Engine *engine,
                   const char *url,
                   const char *host,
                   const char *tab_host,
                   bool third_party,
                   const char *resource_type,
+                  bool *did_match_rule,
                   bool *did_match_exception,
                   bool *did_match_important,
-                  char **redirect,
-                  bool previously_matched_rule,
-                  bool force_check_exceptions);
+                  char **redirect);
 
 /**
  * Adds a tag to the engine for consideration

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -43,22 +43,21 @@ Engine::Engine() : raw(engine_create("")) {
 Engine::Engine(const std::string& rules) : raw(engine_create(rules.c_str())) {
 }
 
-bool Engine::matches(const std::string& url, const std::string& host,
+void Engine::matches(const std::string& url, const std::string& host,
     const std::string& tab_host, bool is_third_party,
-    const std::string& resource_type, bool previously_matched_rule,
-    bool previously_matched_exception, std::string* redirect,
-    bool* did_match_exception, bool* did_match_important) {
+    const std::string& resource_type, bool* did_match_rule,
+    bool* did_match_exception, bool* did_match_important,
+    std::string* redirect) {
   char* redirect_char_ptr = nullptr;
-  bool result = engine_match(raw, url.c_str(), host.c_str(),tab_host.c_str(),
-      is_third_party, resource_type.c_str(), did_match_exception, did_match_important,
-      &redirect_char_ptr, previously_matched_rule, previously_matched_exception);
+  engine_match(raw, url.c_str(), host.c_str(), tab_host.c_str(), is_third_party,
+      resource_type.c_str(), did_match_rule, did_match_exception,
+      did_match_important, &redirect_char_ptr);
   if (redirect_char_ptr) {
     if (redirect) {
       *redirect = redirect_char_ptr;
     }
     c_char_buffer_destroy(redirect_char_ptr);
   }
-  return result;
 }
 
 bool Engine::deserialize(const char* data, size_t data_size) {

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -63,11 +63,11 @@ class ADBLOCK_EXPORT Engine {
  public:
   Engine();
   Engine(const std::string& rules);
-  bool matches(const std::string& url, const std::string& host,
+  void matches(const std::string& url, const std::string& host,
       const std::string& tab_host, bool is_third_party,
-      const std::string& resource_type, bool previously_matched_rule,
-      bool previously_matched_exception, std::string *redirect,
-      bool* did_match_exception, bool* did_match_important);
+      const std::string& resource_type, bool* did_match_rule,
+      bool* did_match_exception, bool* did_match_important,
+      std::string* redirect);
   bool deserialize(const char* data, size_t data_size);
   void addTag(const std::string& tag);
   void addResource(const std::string& key,


### PR DESCRIPTION
This provides a much more natural API for interacting with multiple adblock engines, as we do in the browser. This allows the same parameters to be passed through different engines in sequence without maintaining external state.

Hopefully the last reworking required for https://github.com/brave/brave-core/pull/7666