### PR TITLE
Allow building with embedded-domain-resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ name = "adblock"
 
 [features]
 cbindgen = []
+embedded-domain-resolver = ["adblock/embedded-domain-resolver"]
 
 [profile.dev]
 panic = "abort"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 CFLAGS :=
+CARGOFLAGS :=
 
 ifdef NDEBUG
 CFLAGS += -DNDEBUG=${NDEBUG}
@@ -6,6 +7,11 @@ endif
 
 ifdef NO_CXXEXCEPTIONS
 CFLAGS += -DNO_CXXEXCEPTIONS=${NO_CXXEXCEPTIONS}
+endif
+
+ifdef EMBEDDED_DOMAIN_RESOLVER
+CARGOFLAGS += --features=embedded-domain-resolver
+CFLAGS += -DEMBEDDED_DOMAIN_RESOLVER
 endif
 
 all: examples/cpp.out
@@ -23,7 +29,7 @@ examples/wrapper.o: src/lib.h src/wrapper.cc src/wrapper.h
 	g++ $(CFLAGS) -std=gnu++0x src/wrapper.cc -I src/ -c  -o examples/wrapper.o
 
 target/debug/libadblock.a: src/lib.rs Cargo.toml
-	cargo build
+	cargo build $(CARGOFLAGS)
 
 valgrind-supp: sample
 	valgrind --gen-suppressions=all --suppressions=.valgrind.supp  --leak-check=yes --error-exitcode=1 ./examples/cpp.out --gen-suppressions=all

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -23,3 +23,4 @@ features = ["cbindgen"]
 prefix = "C_"
 
 [defines]
+"feature = embedded-domain-resolver" = "EMBEDDED_DOMAIN_RESOLVER"

--- a/examples/cpp/main.cc
+++ b/examples/cpp/main.cc
@@ -400,7 +400,9 @@ void domainResolverImpl(const char* host, uint32_t* start, uint32_t* end) {
 }
 
 int main() {
+#ifndef EMBEDDED_DOMAIN_RESOLVER
   SetDomainResolver(domainResolverImpl);
+#endif
 
   TestBasics();
   TestDeserialization();

--- a/src/lib.h
+++ b/src/lib.h
@@ -11,13 +11,16 @@
  */
 typedef struct C_Engine C_Engine;
 
+#if !defined(EMBEDDED_DOMAIN_RESOLVER)
 /**
  * An external callback that receives a hostname and two out-parameters for start and end
  * position. The callback should fill the start and end positions with the start and end indices
  * of the domain part of the hostname.
  */
 typedef void (*C_DomainResolverCallback)(const char*, uint32_t*, uint32_t*);
+#endif
 
+#if !defined(EMBEDDED_DOMAIN_RESOLVER)
 /**
  * Passes a callback to the adblock library, allowing it to be used for domain resolution.
  *
@@ -26,6 +29,7 @@ typedef void (*C_DomainResolverCallback)(const char*, uint32_t*, uint32_t*);
  * Returns true on success, false if a callback was already set previously.
  */
 bool set_domain_resolver(C_DomainResolverCallback resolver);
+#endif
 
 /**
  * Create a new `Engine`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use std::string::String;
 /// An external callback that receives a hostname and two out-parameters for start and end
 /// position. The callback should fill the start and end positions with the start and end indices
 /// of the domain part of the hostname.
+#[cfg(not(feature = "embedded-domain-resolver"))]
 pub type DomainResolverCallback = unsafe extern "C" fn(*const c_char, *mut u32, *mut u32);
 
 /// Passes a callback to the adblock library, allowing it to be used for domain resolution.
@@ -17,6 +18,7 @@ pub type DomainResolverCallback = unsafe extern "C" fn(*const c_char, *mut u32, 
 /// This is required to be able to use any adblocking functionality.
 ///
 /// Returns true on success, false if a callback was already set previously.
+#[cfg(not(feature = "embedded-domain-resolver"))]
 #[no_mangle]
 pub unsafe extern "C" fn set_domain_resolver(resolver: DomainResolverCallback) -> bool {
     struct RemoteResolverImpl {

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -8,9 +8,11 @@ extern "C" {
 
 namespace adblock {
 
+#ifndef EMBEDDED_DOMAIN_RESOLVER
 bool SetDomainResolver(DomainResolverCallback resolver) {
   return set_domain_resolver(resolver);
 }
+#endif
 
 std::vector<FilterList> FilterList::default_list;
 std::vector<FilterList> FilterList::regional_list;

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -28,9 +28,11 @@ extern "C" {
 
 namespace adblock {
 
+#ifndef EMBEDDED_DOMAIN_RESOLVER
 typedef C_DomainResolverCallback DomainResolverCallback;
 
 bool ADBLOCK_EXPORT SetDomainResolver(DomainResolverCallback resolver);
+#endif
 
 class ADBLOCK_EXPORT FilterList {
  public:


### PR DESCRIPTION
Currently, the bindings require client code to set an external domain
resolver, which can be cumbersome, as the embedded one suffices. This
commit adds a feature that enables embedded-domain-resolver in
adblock-rust and conditionally hides the setter from the bindings.

Related: https://github.com/brave/adblock-rust-ffi/issues/35