### PR TITLE
Update regex dependency version due to a vulnerability.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ version = "0.1.0"
 dependencies = [
  "adblock",
  "libc",
+ "regex",
  "serde_json",
 ]
 
@@ -216,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 adblock = { version = "~0.3.15", default-features = false, features = ["full-regex-handling", "object-pooling"] }
 serde_json = "1.0"
 libc = "0.2"
+regex = "1.5.5"
 
 [lib]
 crate-type = [


### PR DESCRIPTION
A new vulnerability has been discovered in regex version 1.5.4. This change is to update it to a safe and stable version. The vulnerability is described here: https://rustsec.org/advisories/RUSTSEC-2022-0013