### PR TITLE
Backport from brave-core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 /target/
 **/*.rs.bk
+Cargo.lock
 .gdb_history

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -11,7 +11,7 @@ rust_ffi("adblock_rust_ffi") {
   sources = [
     "src/lib.h",
     "src/wrapper.cc",
-    "src/wrapper.h"
+    "src/wrapper.h",
   ]
 }
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "adblock"
-version = "0.3.15"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9106f026aebe0d8924a0c520e999b406629cd5b336c0b19743542ec1092134"
+checksum = "27785ef5b89bc88fd2def3e1ecfefdf5ec1583795b916667afd15b13058f8315"
 dependencies = [
  "base64",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Brian R. Bondy <netzen@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-adblock = { version = "~0.3.15", default-features = false, features = ["full-regex-handling", "object-pooling"] }
+adblock = { version = "0.5.5", default-features = false, features = ["full-regex-handling", "object-pooling"] }
 serde_json = "1.0"
 libc = "0.2"
 

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ sample: examples/cpp.out
 	./examples/cpp.out
 
 examples/cpp.out: target/debug/libadblock.a examples/wrapper.o examples/cpp/main.cc
-	g++ $(CFLAGS) -std=gnu++0x examples/cpp/main.cc examples/wrapper.o ./target/debug/libadblock.a -I ./src -lpthread -ldl -o examples/cpp.out
+	g++ $(CFLAGS) -std=c++17 examples/cpp/main.cc examples/wrapper.o ./target/debug/libadblock.a -I ./src -lpthread -ldl -o examples/cpp.out
 
 examples/wrapper.o: src/lib.h src/wrapper.cc src/wrapper.h
-	g++ $(CFLAGS) -std=gnu++0x src/wrapper.cc -I src/ -c  -o examples/wrapper.o
+	g++ $(CFLAGS) -std=c++17 src/wrapper.cc -I src/ -c  -o examples/wrapper.o
 
 target/debug/libadblock.a: src/lib.rs Cargo.toml
 	cargo build

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -2,6 +2,13 @@
 language = "C"
 include_guard = "ADBLOCK_RUST_FFI_H"
 
+header = """
+/* Copyright (c) 2019 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */"""
+line_length = 80
+
 [parse]
 # Whether to parse dependent crates and include their types in the generated
 # bindings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
+use adblock::blocker::Redirection;
 use adblock::engine::Engine;
-use adblock::resources::{Resource, ResourceType, MimeType};
+use adblock::lists::FilterListMetadata;
+use adblock::resources::{MimeType, Resource, ResourceType};
 use core::ptr;
 use libc::size_t;
 use std::ffi::CStr;
@@ -38,17 +40,77 @@ pub unsafe extern "C" fn set_domain_resolver(resolver: DomainResolverCallback) -
         }
     }
 
-    adblock::url_parser::set_domain_resolver(Box::new(RemoteResolverImpl { remote_callback: resolver })).is_ok()
+    adblock::url_parser::set_domain_resolver(Box::new(RemoteResolverImpl {
+        remote_callback: resolver,
+    }))
+    .is_ok()
 }
 
-/// Create a new `Engine`.
+/// Create a new `Engine`, interpreting `data` as a C string and then parsing as a filter list in
+/// ABP syntax.
+#[no_mangle]
+pub unsafe extern "C" fn engine_create_from_buffer(
+    data: *const c_char,
+    data_size: size_t,
+) -> *mut Engine {
+    let data: &[u8] = std::slice::from_raw_parts(data as *const u8, data_size);
+    let rules = std::str::from_utf8(data).unwrap_or_else(|_| {
+        eprintln!("Failed to parse filter list with invalid UTF-8 content");
+        ""
+    });
+    engine_create_from_str(rules).1
+}
+
+/// Create a new `Engine`, interpreting `data` as a C string and then parsing as a filter list in
+/// ABP syntax. Also populates metadata from the filter list into `metadata`.
+#[no_mangle]
+pub unsafe extern "C" fn engine_create_from_buffer_with_metadata(
+    data: *const c_char,
+    data_size: size_t,
+    metadata: *mut *mut FilterListMetadata,
+) -> *mut Engine {
+    let data: &[u8] = std::slice::from_raw_parts(data as *const u8, data_size);
+    let rules = std::str::from_utf8(data).unwrap_or_else(|_| {
+        eprintln!("Failed to parse filter list with invalid UTF-8 content");
+        ""
+    });
+    let (metadata_ptr, engine_ptr) = engine_create_from_str(rules);
+    *metadata = metadata_ptr;
+    engine_ptr
+}
+
+/// Create a new `Engine`, interpreting `rules` as a null-terminated C string and then parsing as a
+/// filter list in ABP syntax.
 #[no_mangle]
 pub unsafe extern "C" fn engine_create(rules: *const c_char) -> *mut Engine {
-    let rules = CStr::from_ptr(rules).to_str().unwrap();
+    let rules = CStr::from_ptr(rules).to_str().unwrap_or_else(|_| {
+        eprintln!("Failed to parse filter list with invalid UTF-8 content");
+        ""
+    });
+    engine_create_from_str(rules).1
+}
+
+/// Create a new `Engine`, interpreting `rules` as a null-terminated C string and then parsing as a
+/// filter list in ABP syntax. Also populates metadata from the filter list into `metadata`.
+#[no_mangle]
+pub unsafe extern "C" fn engine_create_with_metadata(rules: *const c_char, metadata: *mut *mut FilterListMetadata) -> *mut Engine {
+    let rules = CStr::from_ptr(rules).to_str().unwrap_or_else(|_|{
+        eprintln!("Failed to parse filter list with invalid UTF-8 content");
+        ""
+    });
+    let (metadata_ptr, engine_ptr) = engine_create_from_str(rules);
+    *metadata = metadata_ptr;
+    engine_ptr
+}
+
+fn engine_create_from_str(rules: &str) -> (*mut FilterListMetadata, *mut Engine) {
     let mut filter_set = adblock::lists::FilterSet::new(false);
-    filter_set.add_filter_list(&rules, adblock::lists::FilterFormat::Standard);
+    let metadata = filter_set.add_filter_list(&rules, Default::default());
     let engine = Engine::from_filter_set(filter_set, true);
-    Box::into_raw(Box::new(engine))
+    (
+        Box::into_raw(Box::new(metadata)),
+        Box::into_raw(Box::new(engine)),
+    )
 }
 
 /// Checks if a `url` matches for the specified `Engine` within the context.
@@ -90,12 +152,40 @@ pub unsafe extern "C" fn engine_match(
     *did_match_exception |= blocker_result.exception.is_some();
     *did_match_important |= blocker_result.important;
     *redirect = match blocker_result.redirect {
-        Some(x) => match CString::new(x) {
+        Some(Redirection::Resource(x)) => match CString::new(x) {
             Ok(y) => y.into_raw(),
             _ => ptr::null_mut(),
         },
+        // Ignore `redirect-url` for now.
+        Some(Redirection::Url(_)) => ptr::null_mut(),
         None => ptr::null_mut(),
     };
+}
+
+/// Returns any CSP directives that should be added to a subdocument or document request's response
+/// headers.
+#[no_mangle]
+pub unsafe extern "C" fn engine_get_csp_directives(
+    engine: *mut Engine,
+    url: *const c_char,
+    host: *const c_char,
+    tab_host: *const c_char,
+    third_party: bool,
+    resource_type: *const c_char,
+) -> *mut c_char {
+    let url = CStr::from_ptr(url).to_str().unwrap();
+    let host = CStr::from_ptr(host).to_str().unwrap();
+    let tab_host = CStr::from_ptr(tab_host).to_str().unwrap();
+    let resource_type = CStr::from_ptr(resource_type).to_str().unwrap();
+    assert!(!engine.is_null());
+    let engine = Box::leak(Box::from_raw(engine));
+    if let Some(directive) =
+        engine.get_csp_directives(url, host, tab_host, resource_type, Some(third_party))
+    {
+        CString::new(directive).expect("Error: CString::new()").into_raw()
+    } else {
+        CString::new("").expect("Error: CString::new()").into_raw()
+    }
 }
 
 /// Adds a tag to the engine for consideration
@@ -185,6 +275,48 @@ pub unsafe extern "C" fn engine_destroy(engine: *mut Engine) {
     }
 }
 
+/// Puts a pointer to the homepage of the `FilterListMetadata` into `homepage`. Returns `true` if a homepage was returned.
+#[no_mangle]
+pub unsafe extern "C" fn filter_list_metadata_homepage(metadata: *const FilterListMetadata, homepage: *mut *mut c_char) -> bool {
+    if let Some(this_homepage) = (*metadata).homepage.as_ref() {
+        let cstring = CString::new(this_homepage.as_str());
+        match cstring {
+            Ok(cstring) => {
+                *homepage = cstring.into_raw();
+                true
+            }
+            Err(_) => false,
+        }
+    } else {
+        false
+    }
+}
+
+/// Puts a pointer to the title of the `FilterListMetadata` into `title`. Returns `true` if a title was returned.
+#[no_mangle]
+pub unsafe extern "C" fn filter_list_metadata_title(metadata: *const FilterListMetadata, title: *mut *mut c_char) -> bool {
+    if let Some(this_title) = (*metadata).title.as_ref() {
+        let cstring = CString::new(this_title.as_str());
+        match cstring {
+            Ok(cstring) => {
+                *title = cstring.into_raw();
+                true
+            }
+            Err(_) => false,
+        }
+    } else {
+        false
+    }
+}
+
+/// Destroy a `FilterListMetadata` once you are done with it.
+#[no_mangle]
+pub unsafe extern "C" fn filter_list_metadata_destroy(metadata: *mut FilterListMetadata) {
+    if !metadata.is_null() {
+        drop(Box::from_raw(metadata));
+    }
+}
+
 /// Destroy a `*c_char` once you are done with it.
 #[no_mangle]
 pub unsafe extern "C" fn c_char_buffer_destroy(s: *mut c_char) {
@@ -202,12 +334,11 @@ pub unsafe extern "C" fn engine_url_cosmetic_resources(
     let url = CStr::from_ptr(url).to_str().unwrap();
     assert!(!engine.is_null());
     let engine = Box::leak(Box::from_raw(engine));
-    let ptr = CString::new(serde_json::to_string(&engine.url_cosmetic_resources(url))
-        .unwrap_or_else(|_| "".into()))
-        .expect("Error: CString::new()")
-        .into_raw();
-    std::mem::forget(ptr);
-    ptr
+    CString::new(
+        serde_json::to_string(&engine.url_cosmetic_resources(url)).unwrap_or_else(|_| "".into()),
+    )
+    .expect("Error: CString::new()")
+    .into_raw()
 }
 
 /// Returns a stylesheet containing all generic cosmetic rules that begin with any of the provided class and id selectors
@@ -238,5 +369,7 @@ pub unsafe extern "C" fn engine_hidden_class_id_selectors(
     assert!(!engine.is_null());
     let engine = Box::leak(Box::from_raw(engine));
     let stylesheet = engine.hidden_class_id_selectors(&classes, &ids, &exceptions);
-    CString::new(serde_json::to_string(&stylesheet).unwrap_or_else(|_| "".into())).expect("Error: CString::new()").into_raw()
+    CString::new(serde_json::to_string(&stylesheet).unwrap_or_else(|_| "".into()))
+        .expect("Error: CString::new()")
+        .into_raw()
 }

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -1,9 +1,13 @@
-#include "wrapper.h"
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "wrapper.h"  // NOLINT https://github.com/brave/brave-browser/issues/14821
 #include <iostream>
-using namespace std;
 
 extern "C" {
-#include "lib.h"
+#include "lib.h"  // NOLINT
 }
 
 namespace adblock {
@@ -34,30 +38,92 @@ FilterList::FilterList(const std::string& uuid,
 
 FilterList::FilterList(const FilterList& other) = default;
 
-FilterList::~FilterList() {
+FilterList::~FilterList() {}
+
+FilterListMetadata::FilterListMetadata() {}
+
+FilterListMetadata::FilterListMetadata(C_FilterListMetadata* metadata) {
+  char* str_buffer;
+
+  if (filter_list_metadata_homepage(metadata, &str_buffer)) {
+    homepage = std::make_optional(std::string(str_buffer));
+    c_char_buffer_destroy(str_buffer);
+  }
+
+  if (filter_list_metadata_title(metadata, &str_buffer)) {
+    title = std::make_optional(std::string(str_buffer));
+    c_char_buffer_destroy(str_buffer);
+  }
 }
 
-Engine::Engine() : raw(engine_create("")) {
+FilterListMetadata::~FilterListMetadata() {}
+
+FilterListMetadata::FilterListMetadata(FilterListMetadata&&) = default;
+
+std::pair<FilterListMetadata, std::unique_ptr<Engine>> engineWithMetadata(
+    const std::string& rules) {
+  C_FilterListMetadata* c_metadata;
+  std::unique_ptr<Engine> engine = std::make_unique<Engine>(
+      engine_create_with_metadata(rules.c_str(), &c_metadata));
+  FilterListMetadata metadata = FilterListMetadata(c_metadata);
+  filter_list_metadata_destroy(c_metadata);
+
+  return std::make_pair(std::move(metadata), std::move(engine));
 }
 
-Engine::Engine(const std::string& rules) : raw(engine_create(rules.c_str())) {
+std::pair<FilterListMetadata, std::unique_ptr<Engine>>
+engineFromBufferWithMetadata(const char* data, size_t data_size) {
+  C_FilterListMetadata* c_metadata;
+  std::unique_ptr<Engine> engine = std::make_unique<Engine>(
+      engine_create_from_buffer_with_metadata(data, data_size, &c_metadata));
+  FilterListMetadata metadata = FilterListMetadata(c_metadata);
+  filter_list_metadata_destroy(c_metadata);
+
+  return std::make_pair(std::move(metadata), std::move(engine));
 }
 
-void Engine::matches(const std::string& url, const std::string& host,
-    const std::string& tab_host, bool is_third_party,
-    const std::string& resource_type, bool* did_match_rule,
-    bool* did_match_exception, bool* did_match_important,
-    std::string* redirect) {
+Engine::Engine(C_Engine* c_engine) : raw(c_engine) {}
+
+Engine::Engine() : raw(engine_create("")) {}
+
+Engine::Engine(const std::string& rules) : raw(engine_create(rules.c_str())) {}
+
+Engine::Engine(const char* data, size_t data_size)
+    : raw(engine_create_from_buffer(data, data_size)) {}
+
+void Engine::matches(const std::string& url,
+                     const std::string& host,
+                     const std::string& tab_host,
+                     bool is_third_party,
+                     const std::string& resource_type,
+                     bool* did_match_rule,
+                     bool* did_match_exception,
+                     bool* did_match_important,
+                     std::string* redirect) {
   char* redirect_char_ptr = nullptr;
   engine_match(raw, url.c_str(), host.c_str(), tab_host.c_str(), is_third_party,
-      resource_type.c_str(), did_match_rule, did_match_exception,
-      did_match_important, &redirect_char_ptr);
+               resource_type.c_str(), did_match_rule, did_match_exception,
+               did_match_important, &redirect_char_ptr);
   if (redirect_char_ptr) {
     if (redirect) {
       *redirect = redirect_char_ptr;
     }
     c_char_buffer_destroy(redirect_char_ptr);
   }
+}
+
+std::string Engine::getCspDirectives(const std::string& url,
+                                     const std::string& host,
+                                     const std::string& tab_host,
+                                     bool is_third_party,
+                                     const std::string& resource_type) {
+  char* csp_raw = engine_get_csp_directives(raw, url.c_str(), host.c_str(),
+                                            tab_host.c_str(), is_third_party,
+                                            resource_type.c_str());
+  const std::string csp = std::string(csp_raw);
+
+  c_char_buffer_destroy(csp_raw);
+  return csp;
 }
 
 bool Engine::deserialize(const char* data, size_t data_size) {
@@ -77,8 +143,8 @@ bool Engine::tagExists(const std::string& tag) {
 }
 
 void Engine::addResource(const std::string& key,
-    const std::string& content_type,
-    const std::string &data) {
+                         const std::string& content_type,
+                         const std::string& data) {
   engine_add_resource(raw, key.c_str(), content_type.c_str(), data.c_str());
 }
 
@@ -94,31 +160,31 @@ const std::string Engine::urlCosmeticResources(const std::string& url) {
   return resources_json;
 }
 
-const std::string Engine::hiddenClassIdSelectors(const std::vector<std::string>& classes, const std::vector<std::string>& ids, const std::vector<std::string>& exceptions) {
+const std::string Engine::hiddenClassIdSelectors(
+    const std::vector<std::string>& classes,
+    const std::vector<std::string>& ids,
+    const std::vector<std::string>& exceptions) {
   std::vector<const char*> classes_raw;
   classes_raw.reserve(classes.size());
-  for(size_t i = 0; i < classes.size(); i++) {
+  for (size_t i = 0; i < classes.size(); i++) {
     classes_raw.push_back(classes[i].c_str());
   }
 
   std::vector<const char*> ids_raw;
   ids_raw.reserve(ids.size());
-  for(size_t i = 0; i < ids.size(); i++) {
+  for (size_t i = 0; i < ids.size(); i++) {
     ids_raw.push_back(ids[i].c_str());
   }
 
   std::vector<const char*> exceptions_raw;
   exceptions_raw.reserve(exceptions.size());
-  for(size_t i = 0; i < exceptions.size(); i++) {
+  for (size_t i = 0; i < exceptions.size(); i++) {
     exceptions_raw.push_back(exceptions[i].c_str());
   }
 
   char* stylesheet_raw = engine_hidden_class_id_selectors(
-    raw,
-    classes_raw.data(), classes.size(),
-    ids_raw.data(), ids.size(),
-    exceptions_raw.data(), exceptions.size()
-  );
+      raw, classes_raw.data(), classes.size(), ids_raw.data(), ids.size(),
+      exceptions_raw.data(), exceptions.size());
   const std::string stylesheet = std::string(stylesheet_raw);
 
   c_char_buffer_destroy(stylesheet_raw);


### PR DESCRIPTION
The copy of adblock-rust-ffi living in brave-core has been updated.
This commit backports all the valuable changes.

First, does it make sense to make pull request to this repo? It seems abandoned.

I did not backport changes that were made just for Brave like the change to the crate type or the `#include` of `raw_ptr`.
I had to move from gnu++0x to c++17 to use `std::optional` instead of `absl::optional`, not sure if this is acceptable.
I had to fix 2 tests because of the addition of try/catch blocks and "disable" 1 test because of an upstream breaking change in `adblock-rust`.
